### PR TITLE
Update solver component to use wfc v0.1.0

### DIFF
--- a/Types/Direction.cs
+++ b/Types/Direction.cs
@@ -87,6 +87,11 @@ namespace Monoceros {
     /// </summary>
     [Serializable]
     public enum Axis : uint {
+        // TODO(yan): Bring back the Adjacency Rule type from the Rust solver in
+        // the solver component and make conversion functions between this and
+        // it. The adjacency rule enum is volatile and depends on bindings to
+        // the Rust solver. It is dangerous to believe we control this from
+        // here.
         X = 0,
         Y = 1,
         Z = 2,

--- a/Types/Direction.cs
+++ b/Types/Direction.cs
@@ -87,11 +87,17 @@ namespace Monoceros {
     /// </summary>
     [Serializable]
     public enum Axis : uint {
-        // TODO(yan): Bring back the Adjacency Rule type from the Rust solver in
-        // the solver component and make conversion functions between this and
-        // it. The adjacency rule enum is volatile and depends on bindings to
-        // the Rust solver. It is dangerous to believe we control this from
-        // here.
+        // TODO(yan): Bring back the AdjacencyRule type from the Rust solver in
+        // the solver component and make conversion functions between this one
+        // and that.
+        //
+        // Note that this type is sent across FFI and its memory layout must be
+        // exactly the same as the one defined in C API headers for the Rust
+        // solver. It is dangerous to believe we control this from
+        // here. Theferore it would be best if the raw FFI type would be defined
+        // in Solver.cs, close to the FFI bindings. Conversions can be defined
+        // between Axis (which will no longer have to be uint) and
+        // AdjacencyKind.
         X = 0,
         Y = 1,
         Z = 2,


### PR DESCRIPTION
This patch updates the DLL bindings to the new Rust solver v0.1.0.

The two major changes are:

1) RNG and World state are now initialized and freed separately
2) Grasshopper solver component is now responsible for the attempt loop

Besides that I took the liberty of changing some `var`s back to `uint`s/`ushort`s, etc... For bit manipulation we want to be exact. It may be that C# inferred the correct types, but there were at least a few sites where it inferred them incorrectly - when I replaced `var` with the correct numeric type, it caused a type error which I had to fixup with explicit casts. I wonder if this already caused bugs. Also I find it better documentation to use explicit types if they are this important. I am fine with `var` everywhere else, where it can not cause subtle and dangerous errors.

I also added a TODO to bring back `AdjacencyKind` enum. It was there to model the type as exposed by the C API of the Rust solver. The `Axis` enum actually does not belong to Monoceros, but this wasn't documented anywhere. This could lead to potentially deadly bugs in the future, if anyone forgets the type is actually volatile and always has to mirror the WFC one.

I only tested on the Mondieu project and it seemed to behave well, but @janper please test extensively on all examples. I don't know this codebase well.

Fixes #15 